### PR TITLE
Refactor admin dashboard with analytics

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -5,42 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <title>Admin - Receituário Pro</title>
-    
-    <!-- Supabase -->
+
+    <!-- Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    
+
     <style>
         :root {
             --primary: #667eea;
-            --primary-dark: #5a67d8;
             --secondary: #764ba2;
             --gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             --text-dark: #1a202c;
             --text-light: #718096;
-            --white: #ffffff;
             --gray-light: #f7fafc;
-            --gray-lighter: #edf2f7;
+            --white: #ffffff;
             --success: #48bb78;
-            --error: #f56565;
-            --warning: #ed8936;
-            --info: #4299e1;
         }
-        
+
         * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
             background: var(--gray-light);
             min-height: 100vh;
         }
-        
-        /* Loading Screen */
+
+        /* Loading */
         .loading-screen {
             position: fixed;
             top: 0;
@@ -51,1302 +47,210 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            z-index: 10000;
+            color: white;
+            z-index: 1000;
             transition: opacity 0.3s;
         }
-        
-        .loading-screen.hidden {
-            opacity: 0;
-            pointer-events: none;
-        }
-        
-        .loading-content {
-            text-align: center;
-            color: white;
-        }
-        
-        .loading-spinner {
-            width: 50px;
-            height: 50px;
-            border: 4px solid rgba(255,255,255,0.3);
-            border-top-color: white;
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 1rem;
-        }
-        
-        @keyframes spin {
-            to { transform: rotate(360deg); }
-        }
-        
-        /* Dashboard */
-        .dashboard {
-            display: none;
-        }
-        
-        .dashboard.active {
-            display: block;
-        }
-        
+
+        .loading-screen.hidden { opacity: 0; pointer-events: none; }
+
+        .dashboard { display: none; }
+        .dashboard.active { display: block; }
+
         /* Header */
         .admin-header {
             background: white;
             padding: 1rem 2rem;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
             display: flex;
             justify-content: space-between;
             align-items: center;
-        }
-        
-        .admin-logo {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-        
-        .admin-logo img {
-            height: 32px;
-        }
-        
-        .admin-logo span {
-            font-weight: 700;
-            font-size: 1.25rem;
-            background: var(--gradient);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-        
-        .admin-user {
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-        }
-        
-        .admin-user-info {
-            text-align: right;
-        }
-        
-        .admin-user-name {
-            font-weight: 600;
-            color: var(--text-dark);
-        }
-        
-        .admin-user-role {
-            font-size: 0.85rem;
-            color: var(--text-light);
-        }
-        
-        .btn-logout {
-            padding: 0.5rem 1rem;
-            background: var(--error);
-            color: white;
-            border: none;
-            border-radius: 8px;
-            cursor: pointer;
-            font-weight: 500;
-            transition: all 0.3s;
-        }
-        
-        .btn-logout:hover {
-            background: #e53e3e;
-            transform: translateY(-1px);
-        }
-        
-        /* Main Content */
-        .main-content {
-            padding: 2rem;
-            max-width: 1400px;
-            margin: 0 auto;
-        }
-        
-        .page-title {
-            font-size: 1.75rem;
-            font-weight: 700;
-            color: var(--text-dark);
-            margin-bottom: 2rem;
-        }
-        
-        /* Stats Cards */
-        .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 1.5rem;
-            margin-bottom: 2rem;
-        }
-        
-        .stat-card {
-            background: white;
-            padding: 1.5rem;
-            border-radius: 12px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            transition: transform 0.3s;
-        }
-        
-        .stat-card:hover {
-            transform: translateY(-2px);
-        }
-        
-        .stat-icon {
-            width: 60px;
-            height: 60px;
-            border-radius: 12px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.5rem;
-        }
-        
-        .stat-icon.blue {
-            background: rgba(66, 153, 225, 0.1);
-            color: var(--info);
-        }
-        
-        .stat-icon.green {
-            background: rgba(72, 187, 120, 0.1);
-            color: var(--success);
-        }
-        
-        .stat-icon.yellow {
-            background: rgba(237, 137, 54, 0.1);
-            color: var(--warning);
-        }
-        
-        .stat-icon.purple {
-            background: rgba(102, 126, 234, 0.1);
-            color: var(--primary);
-        }
-        
-        .stat-content {
-            flex: 1;
-        }
-        
-        .stat-label {
-            color: var(--text-light);
-            font-size: 0.9rem;
-            margin-bottom: 0.25rem;
-        }
-        
-        .stat-value {
-            font-size: 1.75rem;
-            font-weight: 700;
-            color: var(--text-dark);
-        }
-        
-        .stat-change {
-            font-size: 0.85rem;
-            margin-top: 0.25rem;
-            color: var(--text-light);
-        }
-        
-        /* Tables */
-        .table-container {
-            background: white;
-            border-radius: 12px;
-            padding: 1.5rem;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-            margin-bottom: 2rem;
-            overflow-x: auto;
-        }
-        
-        .table-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1.5rem;
-            flex-wrap: wrap;
-            gap: 1rem;
-        }
-        
-        .table-title {
-            font-size: 1.25rem;
-            font-weight: 600;
-            color: var(--text-dark);
-        }
-        
-        .table-actions {
-            display: flex;
-            gap: 1rem;
-        }
-        
-        .btn-refresh {
-            padding: 0.5rem 1rem;
-            background: var(--primary);
-            color: white;
-            border: none;
-            border-radius: 8px;
-            cursor: pointer;
-            font-weight: 500;
-            transition: all 0.3s;
-        }
-        
-        .btn-refresh:hover {
-            background: var(--primary-dark);
-        }
-        
-        table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        
-        thead {
-            background: var(--gray-light);
-        }
-        
-        th {
-            padding: 1rem;
-            text-align: left;
-            font-weight: 600;
-            color: var(--text-dark);
-            font-size: 0.9rem;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        td {
-            padding: 1rem;
-            border-top: 1px solid var(--gray-lighter);
-            color: var(--text-dark);
-        }
-        
-        tbody tr:hover {
-            background: var(--gray-light);
-        }
-        
-        .status-badge {
-            display: inline-block;
-            padding: 0.25rem 0.75rem;
-            border-radius: 20px;
-            font-size: 0.85rem;
-            font-weight: 500;
-        }
-        
-        .status-badge.pending {
-            background: rgba(237, 137, 54, 0.1);
-            color: var(--warning);
-        }
-        
-        .status-badge.active {
-            background: rgba(72, 187, 120, 0.1);
-            color: var(--success);
-        }
-        
-        .status-badge.rejected {
-            background: rgba(245, 101, 101, 0.1);
-            color: var(--error);
-        }
-        
-        .action-buttons {
-            display: flex;
-            gap: 0.5rem;
-            flex-wrap: wrap;
-        }
-        
-        .btn-action {
-            padding: 0.375rem 0.75rem;
-            border: none;
-            border-radius: 6px;
-            font-size: 0.85rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.3s;
-        }
-        
-        .btn-approve {
-            background: var(--success);
-            color: white;
-        }
-        
-        .btn-approve:hover {
-            background: #38a169;
-        }
-        
-        .btn-reject {
-            background: var(--error);
-            color: white;
-        }
-        
-        .btn-reject:hover {
-            background: #e53e3e;
-        }
-        
-        .btn-view {
-            background: var(--info);
-            color: white;
-        }
-        
-        .btn-view:hover {
-            background: #3182ce;
-        }
-        
-        /* Empty State */
-        .empty-state {
-            text-align: center;
-            padding: 3rem;
-            color: var(--text-light);
-        }
-        
-        .empty-state-icon {
-            font-size: 3rem;
-            margin-bottom: 1rem;
-        }
-        
-        .empty-state-title {
-            font-size: 1.25rem;
-            font-weight: 600;
-            color: var(--text-dark);
-            margin-bottom: 0.5rem;
-        }
-        
-        /* Alert */
-        .alert {
-            padding: 1rem;
-            border-radius: 8px;
-            margin-bottom: 1.5rem;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-        
-        .alert-success {
-            background: rgba(72, 187, 120, 0.1);
-            color: var(--success);
-            border: 1px solid rgba(72, 187, 120, 0.3);
-        }
-        
-        .alert-error {
-            background: rgba(245, 101, 101, 0.1);
-            color: var(--error);
-            border: 1px solid rgba(245, 101, 101, 0.3);
-        }
-        
-        .alert-info {
-            background: rgba(66, 153, 225, 0.1);
-            color: var(--info);
-            border: 1px solid rgba(66, 153, 225, 0.3);
-        }
-        
-        /* Modal */
-        .modal {
-            display: none;
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 1000;
-            align-items: center;
-            justify-content: center;
-        }
-        
-        .modal.show {
-            display: flex;
-        }
-        
-        .modal-content {
-            background: white;
-            border-radius: 16px;
-            padding: 2rem;
-            max-width: 600px;
-            width: 90%;
-            max-height: 90vh;
-            overflow-y: auto;
-        }
-        
-        .modal-header {
-            margin-bottom: 1.5rem;
-        }
-        
-        .modal-title {
-            font-size: 1.5rem;
-            font-weight: 700;
-            color: var(--text-dark);
-        }
-        
-        .modal-body {
-            margin-bottom: 1.5rem;
-        }
-        
-        .modal-footer {
-            display: flex;
-            justify-content: flex-end;
-            gap: 1rem;
-        }
-        
-        .info-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 1rem;
-            margin-top: 1rem;
-        }
-        
-        .info-item {
-            padding: 0.75rem;
-            background: var(--gray-light);
-            border-radius: 8px;
-        }
-        
-        .info-label {
-            font-size: 0.85rem;
-            color: var(--text-light);
-            margin-bottom: 0.25rem;
-        }
-        
-        .info-value {
-            font-weight: 600;
-            color: var(--text-dark);
-        }
-        
-        .btn {
-            padding: 0.75rem 1.5rem;
-            border: none;
-            border-radius: 8px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.3s;
-        }
-        
-        .btn-primary {
-            background: var(--gradient);
-            color: white;
-        }
-        
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
-        }
-        
-        .btn-secondary {
-            background: var(--gray-light);
-            color: var(--text-dark);
-        }
-        
-        .btn-secondary:hover {
-            background: var(--gray-lighter);
-        }
-        
-        /* Responsive */
-        @media (max-width: 768px) {
-            .main-content {
-                padding: 1rem;
-            }
-            
-            .stats-grid {
-                grid-template-columns: 1fr;
-            }
-            
-            .table-container {
-                padding: 1rem;
-            }
-            
-            .info-grid {
-                grid-template-columns: 1fr;
-            }
-            
-            .admin-header {
-                padding: 1rem;
-            }
-            
-            .admin-logo span {
-                display: none;
-            }
-        }
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+
+        .admin-logo { display: flex; align-items: center; gap: 0.75rem; }
+        .admin-logo img { height: 32px; }
+        .admin-logo span { font-weight: 700; font-size: 1.25rem; background: var(--gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+
+        .admin-user { display: flex; align-items: center; gap: 1rem; }
+        .btn-logout { padding: 0.5rem 1rem; background: var(--success); color: white; border: none; border-radius: 8px; cursor: pointer; }
+
+        .main-content { padding: 2rem; max-width: 1400px; margin: 0 auto; }
+        .page-title { font-size: 1.75rem; font-weight: 700; color: var(--text-dark); margin-bottom: 2rem; }
+
+        /* Stats */
+        .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px,1fr)); gap: 1.5rem; margin-bottom: 2rem; }
+        .stat-card { background: white; padding: 1.5rem; border-radius: 12px; box-shadow: 0 2px 10px rgba(0,0,0,0.05); }
+        .stat-title { font-size: 0.9rem; color: var(--text-light); margin-bottom: 0.5rem; }
+        .stat-value { font-size: 1.8rem; font-weight: 700; color: var(--text-dark); }
+
+        /* Charts */
+        .charts-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px,1fr)); gap: 2rem; }
+        .chart-card { background: white; padding: 1.5rem; border-radius: 12px; box-shadow: 0 2px 10px rgba(0,0,0,0.05); }
+        .chart-card h2 { font-size: 1.1rem; margin-bottom: 1rem; color: var(--text-dark); }
     </style>
 </head>
 <body>
-    <!-- Loading Screen -->
     <div class="loading-screen" id="loadingScreen">
-        <div class="loading-content">
-            <div class="loading-spinner"></div>
-            <p>Carregando painel administrativo...</p>
-        </div>
+        <div>Carregando...</div>
     </div>
-    
-    <!-- Dashboard -->
+
     <div class="dashboard" id="dashboard">
-        <!-- Header -->
         <header class="admin-header">
             <div class="admin-logo">
-                <img src="img/saas-logo.png" alt="Logo">
-                <span>Admin Panel</span>
+                <img src="img/logo.png" alt="Logo">
+                <span>Receituário Pro</span>
             </div>
-            
             <div class="admin-user">
-                <div class="admin-user-info">
-                    <div class="admin-user-name">Administrador</div>
-                    <div class="admin-user-role">techne.br@gmail.com</div>
-                </div>
+                <span id="adminName"></span>
                 <button class="btn-logout" onclick="logout()">Sair</button>
             </div>
         </header>
-        
-        <div class="main-content">
-            <!-- Alerts -->
-            <div id="alertContainer"></div>
-            
-            <!-- Dashboard Stats -->
-            <h1 class="page-title">Dashboard Administrativo</h1>
-            
-                    <div class="stats-grid">
-                        <div class="stat-card">
-                            <div class="stat-icon blue">👥</div>
-                            <div class="stat-content">
-                                <div class="stat-label">Total de Profissionais</div>
-                                <div class="stat-value" id="totalUsersCount">0</div>
-                                <div class="stat-change positive">Cadastros ativos</div>
-                            </div>
-                        </div>
-                        
-                        <div class="stat-card">
-                            <div class="stat-icon yellow">🎁</div>
-                            <div class="stat-content">
-                                <div class="stat-label">Usuários em Trial</div>
-                                <div class="stat-value" id="trialUsersCount">0</div>
-                                <div class="stat-change">30 dias grátis</div>
-                            </div>
-                        </div>
-                        
-                        <div class="stat-card">
-                            <div class="stat-icon green">💰</div>
-                            <div class="stat-content">
-                                <div class="stat-label">Usuários Pagantes</div>
-                                <div class="stat-value" id="paidUsersCount">0</div>
-                                <div class="stat-change positive">Plano Essencial</div>
-                            </div>
-                        </div>
-                        
-                        <div class="stat-card">
-                            <div class="stat-icon purple">📋</div>
-                            <div class="stat-content">
-                                <div class="stat-label">Receituários/Mês</div>
-                                <div class="stat-value" id="monthlyPrescriptionsCount">0</div>
-                                <div class="stat-change positive">Sem limite</div>
-                            </div>
-                        </div>
-                    </div>
-            
-            <!-- Pending Validations -->
-            <div class="table-container">
-                <div class="table-header">
-                    <h2 class="table-title">🔍 Profissionais Aguardando Validação</h2>
-                    <div class="table-actions">
-                        <button class="btn-refresh" onclick="loadPendingProfessionals()">
-                            🔄 Atualizar
-                        </button>
-                    </div>
+
+        <main class="main-content">
+            <h1 class="page-title">Relatório Geral</h1>
+
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-title">Novos usuários (mês)</div>
+                    <div class="stat-value" id="newUsers">0</div>
                 </div>
-                
-                <div id="pendingTableContent">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Data</th>
-                                <th>Nome</th>
-                                <th>Conselho</th>
-                                <th>Registro</th>
-                                <th>E-mail</th>
-                                <th>Especialidade</th>
-                                <th>Status</th>
-                                <th>Ações</th>
-                            </tr>
-                        </thead>
-                        <tbody id="pendingList">
-                            <tr>
-                                <td colspan="8" class="empty-state">
-                                    <div class="empty-state-icon">📭</div>
-                                    <div class="empty-state-title">Nenhuma validação pendente</div>
-                                    <p>Novos cadastros aparecerão aqui</p>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                <div class="stat-card">
+                    <div class="stat-title">Trials ativos</div>
+                    <div class="stat-value" id="trialUsers">0</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-title">Assinaturas ativas</div>
+                    <div class="stat-value" id="activeUsers">0</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-title">Mensal / Anual</div>
+                    <div class="stat-value"><span id="monthlySubs">0</span> / <span id="yearlySubs">0</span></div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-title">Receita mensal</div>
+                    <div class="stat-value" id="monthlyRevenue">R$ 0,00</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-title">Receita projetada</div>
+                    <div class="stat-value" id="projectedRevenue">R$ 0,00</div>
                 </div>
             </div>
-            
-            <!-- All Professionals -->
-            <div class="table-container">
-                <div class="table-header">
-                    <h2 class="table-title">👨‍⚕️ Todos os Profissionais</h2>
-                    <div class="table-actions">
-                        <button class="btn-refresh" onclick="loadAllProfessionals()">
-                            🔄 Atualizar
-                        </button>
-                    </div>
+
+            <div class="charts-grid">
+                <div class="chart-card">
+                    <h2>Novos usuários por mês</h2>
+                    <canvas id="usersChart"></canvas>
                 </div>
-                
-                <div id="allProfessionalsTableContent">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Cadastro</th>
-                                <th>Nome</th>
-                                <th>Conselho</th>
-                                <th>Especialidade</th>
-                                <th>Plano</th>
-                                <th>Receituários</th>
-                                <th>Status</th>
-                                <th>Ações</th>
-                            </tr>
-                        </thead>
-                        <tbody id="professionalsList">
-                            <tr>
-                                <td colspan="8" class="empty-state">
-                                    <div class="empty-state-icon">👥</div>
-                                    <div class="empty-state-title">Carregando profissionais...</div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                <div class="chart-card">
+                    <h2>Distribuição de planos</h2>
+                    <canvas id="planChart"></canvas>
+                </div>
+                <div class="chart-card">
+                    <h2>Projeção de receita</h2>
+                    <canvas id="revenueChart"></canvas>
                 </div>
             </div>
-            
-            <!-- Recent Activity -->
-            <div class="table-container">
-                <div class="table-header">
-                    <h2 class="table-title">📊 Atividade Recente</h2>
-                </div>
-                
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Data/Hora</th>
-                            <th>Tipo</th>
-                            <th>Descrição</th>
-                            <th>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody id="activityList">
-                        <tr>
-                            <td colspan="4" class="empty-state">
-                                <div class="empty-state-icon">📈</div>
-                                <div class="empty-state-title">Monitorando atividades...</div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        </main>
     </div>
-    
-    <!-- Professional Details Modal -->
-    <div class="modal" id="professionalModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="modal-title">Detalhes do Profissional</h2>
-            </div>
-            <div class="modal-body">
-                <div class="info-grid">
-                    <div class="info-item">
-                        <div class="info-label">Nome Completo</div>
-                        <div class="info-value" id="modalName">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">E-mail</div>
-                        <div class="info-value" id="modalEmail">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Conselho</div>
-                        <div class="info-value" id="modalCouncil">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Registro</div>
-                        <div class="info-value" id="modalRegister">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Especialidade</div>
-                        <div class="info-value" id="modalSpecialty">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Telefone</div>
-                        <div class="info-value" id="modalPhone">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Data de Cadastro</div>
-                        <div class="info-value" id="modalDate">-</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Status</div>
-                        <div class="info-value" id="modalStatus">-</div>
-                    </div>
-                </div>
-                
-                <div id="modalValidationNote" style="margin-top: 1.5rem; padding: 1rem; background: var(--gray-light); border-radius: 8px; display: none;">
-                    <strong>Nota de Validação:</strong>
-                    <p id="modalValidationText" style="margin-top: 0.5rem;"></p>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-secondary" onclick="closeModal()">Fechar</button>
-                <button id="modalApproveBtn" class="btn btn-approve" style="display: none;" onclick="">Aprovar</button>
-                <button id="modalRejectBtn" class="btn btn-reject" style="display: none;" onclick="">Rejeitar</button>
-            </div>
-        </div>
-    </div>
-    
-    <!-- Include Supabase Config -->
+
     <script src="js/supabase-config.js"></script>
-    
     <script>
-        // ========================================
-        // VARIÁVEIS GLOBAIS
-        // ========================================
-        let currentUser = null;
-        let allProfessionals = [];
-        let pendingProfessionals = [];
-        
-        // ========================================
-        // INICIALIZAÇÃO
-        // ========================================
-        window.addEventListener('DOMContentLoaded', async () => {
-            await initializeAdmin();
-        });
-        
-        async function initializeAdmin() {
-            try {
-                // Verificar autenticação
-                const { data: { session } } = await supabaseClient.auth.getSession();
-                
-                if (!session) {
-                    window.location.href = 'auth.html';
-                    return;
-                }
-                
-                // Verificar se é admin
-                const { data: user, error } = await supabaseClient
-                    .from('users')
-                    .select('*')
-                    .eq('id', session.user.id)
-                    .single();
-                
-                if (error || !user || !user.is_admin) {
-                    showAlert('Acesso negado. Você não tem permissões administrativas.', 'error');
-                    setTimeout(() => {
-                        window.location.href = 'index.html';
-                    }, 2000);
-                    return;
-                }
-                
-                currentUser = user;
-                
-                // Mostrar dashboard
-                document.getElementById('loadingScreen').classList.add('hidden');
-                document.getElementById('dashboard').classList.add('active');
-                
-                // Carregar dados
-                await loadDashboardData();
-                
-                // Configurar auto-refresh a cada 30 segundos
-                setInterval(loadDashboardData, 30000);
-                
-            } catch (error) {
-                console.error('Erro na inicialização:', error);
-                showAlert('Erro ao carregar painel administrativo', 'error');
-            }
-        }
-        
-        // ========================================
-        // FUNÇÕES DE CARREGAMENTO DE DADOS
-        // ========================================
-        
-        async function loadDashboardData() {
-            try {
-                // Carregar todas as promessas em paralelo para melhor performance
-                const [stats, pending, professionals] = await Promise.all([
-                    loadStatistics(),
-                    loadPendingProfessionals(),
-                    loadAllProfessionals()
-                ]);
-                
-                // Atualizar atividades recentes
-                await loadRecentActivity();
-                
-            } catch (error) {
-                console.error('Erro ao carregar dados:', error);
-                showAlert('Erro ao atualizar dados do dashboard', 'error');
-            }
-        }
-        
-        async function loadStatistics() {
-            try {
-                // Total de profissionais (excluindo admin)
-                const { count: totalUsers, error: error1 } = await supabaseClient
-                    .from('users')
-                    .select('*', { count: 'exact', head: true })
-                    .neq('is_admin', true);
-                
-                // Validações pendentes
-                const { count: pendingCount, error: error2 } = await supabaseClient
-                    .from('users')
-                    .select('*', { count: 'exact', head: true })
-                    .eq('status', 'pending');
-                
-                // Receituários do mês
-                const startOfMonth = new Date();
-                startOfMonth.setDate(1);
-                startOfMonth.setHours(0, 0, 0, 0);
-                
-                const { count: monthlyPrescriptions, error: error3 } = await supabaseClient
-                    .from('prescriptions')
-                    .select('*', { count: 'exact', head: true })
-                    .gte('created_at', startOfMonth.toISOString());
-                
-                // Assinaturas ativas (plano essential)
-                const { data: activeSubscriptions, error: error4 } = await supabaseClient
-                    .from('subscriptions')
-                    .select('*')
-                    .eq('plan', 'essential')
-                    .eq('status', 'active');
-                
-                // Calcular receita mensal
-                const monthlyRevenue = (activeSubscriptions?.length || 0) * 29;
-                
-                // Atualizar UI
-                document.getElementById('totalUsers').textContent = totalUsers || '0';
-                document.getElementById('pendingValidations').textContent = pendingCount || '0';
-                document.getElementById('monthlyRevenue').textContent = `R$ ${monthlyRevenue}`;
-                document.getElementById('monthlyPrescriptions').textContent = monthlyPrescriptions || '0';
-                
-                // Calcular mudanças percentuais (mock por enquanto)
-                document.getElementById('usersChange').textContent = `${totalUsers || 0} profissionais ativos`;
-                document.getElementById('revenueChange').textContent = `${activeSubscriptions?.length || 0} assinaturas ativas`;
-                document.getElementById('prescriptionsChange').textContent = `Mês ${new Date().toLocaleDateString('pt-BR', { month: 'long' })}`;
-                
-                return { totalUsers, pendingCount, monthlyPrescriptions, monthlyRevenue };
-                
-            } catch (error) {
-                console.error('Erro ao carregar estatísticas:', error);
-                throw error;
-            }
-        }
-        
-        async function loadPendingProfessionals() {
-            try {
-                const { data, error } = await supabaseClient
-                    .from('users')
-                    .select('*')
-                    .eq('status', 'pending')
-                    .order('created_at', { ascending: false });
-                
-                if (error) throw error;
-                
-                pendingProfessionals = data || [];
-                
-                const tbody = document.getElementById('pendingList');
-                
-                if (pendingProfessionals.length === 0) {
-                    tbody.innerHTML = `
-                        <tr>
-                            <td colspan="8" class="empty-state">
-                                <div class="empty-state-icon">✅</div>
-                                <div class="empty-state-title">Tudo em dia!</div>
-                                <p>Não há validações pendentes no momento</p>
-                            </td>
-                        </tr>
-                    `;
-                } else {
-                    tbody.innerHTML = pendingProfessionals.map(prof => `
-                        <tr>
-                            <td>${new Date(prof.created_at).toLocaleDateString('pt-BR')}</td>
-                            <td><strong>${prof.name}</strong></td>
-                            <td>${prof.council}-${prof.state}</td>
-                            <td>${prof.registration_number}</td>
-                            <td>${prof.email}</td>
-                            <td>${prof.specialty || '-'}</td>
-                            <td><span class="status-badge pending">Pendente</span></td>
-                            <td>
-                                <div class="action-buttons">
-                                    <button class="btn-action btn-view" onclick="viewProfessional('${prof.id}')">
-                                        👁️ Ver
-                                    </button>
-                                    <button class="btn-action btn-approve" onclick="handleApprove('${prof.id}')">
-                                        ✅ Aprovar
-                                    </button>
-                                    <button class="btn-action btn-reject" onclick="handleReject('${prof.id}')">
-                                        ❌ Rejeitar
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    `).join('');
-                }
-                
-                return pendingProfessionals;
-                
-            } catch (error) {
-                console.error('Erro ao carregar pendentes:', error);
-                showAlert('Erro ao carregar profissionais pendentes', 'error');
-                return [];
-            }
-        }
-        
-        async function loadAllProfessionals() {
-            try {
-                const { data: professionals, error } = await supabaseClient
-                    .from('users')
-                    .select(`
-                        *,
-                        subscriptions (
-                            plan,
-                            status,
-                            prescriptions_count
-                        )
-                    `)
-                    .neq('is_admin', true)
-                    .order('created_at', { ascending: false });
-                
-                if (error) throw error;
-                
-                allProfessionals = professionals || [];
-                
-                const tbody = document.getElementById('professionalsList');
-                
-                if (allProfessionals.length === 0) {
-                    tbody.innerHTML = `
-                        <tr>
-                            <td colspan="8" class="empty-state">
-                                <div class="empty-state-icon">👥</div>
-                                <div class="empty-state-title">Nenhum profissional cadastrado</div>
-                            </td>
-                        </tr>
-                    `;
-                } else {
-                    tbody.innerHTML = allProfessionals.map(prof => {
-                        const subscription = prof.subscriptions?.[0];
-                        const statusClass = prof.status === 'active' ? 'active' : 
-                                          prof.status === 'rejected' ? 'rejected' : 'pending';
-                        const statusText = prof.status === 'active' ? 'Ativo' : 
-                                         prof.status === 'rejected' ? 'Rejeitado' : 'Pendente';
-                        
-                        return `
-                            <tr>
-                                <td>${new Date(prof.created_at).toLocaleDateString('pt-BR')}</td>
-                                <td><strong>${prof.name}</strong></td>
-                                <td>${prof.council}-${prof.state} ${prof.registration_number}</td>
-                                <td>${prof.specialty || '-'}</td>
-                                <td>${subscription?.plan || 'freemium'}</td>
-                                <td>${subscription?.prescriptions_count || 0}</td>
-                                <td><span class="status-badge ${statusClass}">${statusText}</span></td>
-                                <td>
-                                    <button class="btn-action btn-view" onclick="viewProfessional('${prof.id}')">
-                                        👁️ Detalhes
-                                    </button>
-                                </td>
-                            </tr>
-                        `;
-                    }).join('');
-                }
-                
-                return allProfessionals;
-                
-            } catch (error) {
-                console.error('Erro ao carregar profissionais:', error);
-                showAlert('Erro ao carregar lista de profissionais', 'error');
-                return [];
-            }
-        }
-        
-        async function loadRecentActivity() {
-            try {
-                // Buscar últimas atividades (cadastros, aprovações, etc)
-                const { data: recentUsers, error } = await supabaseClient
-                    .from('users')
-                    .select('*')
-                    .neq('is_admin', true)
-                    .order('updated_at', { ascending: false })
-                    .limit(10);
-                
-                if (error) throw error;
-                
-                const tbody = document.getElementById('activityList');
-                
-                if (!recentUsers || recentUsers.length === 0) {
-                    tbody.innerHTML = `
-                        <tr>
-                            <td colspan="4" class="empty-state">
-                                <div class="empty-state-icon">📊</div>
-                                <div class="empty-state-title">Sem atividades recentes</div>
-                            </td>
-                        </tr>
-                    `;
-                } else {
-                    tbody.innerHTML = recentUsers.map(user => {
-                        let type = 'Cadastro';
-                        let description = `${user.name} - ${user.council}/${user.state}`;
-                        let statusClass = 'pending';
-                        let statusText = 'Pendente';
-                        
-                        if (user.status === 'active') {
-                            type = 'Aprovação';
-                            statusClass = 'active';
-                            statusText = 'Aprovado';
-                        } else if (user.status === 'rejected') {
-                            type = 'Rejeição';
-                            statusClass = 'rejected';
-                            statusText = 'Rejeitado';
-                        }
-                        
-                        const date = new Date(user.updated_at);
-                        const dateStr = date.toLocaleDateString('pt-BR');
-                        const timeStr = date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
-                        
-                        return `
-                            <tr>
-                                <td>${dateStr} ${timeStr}</td>
-                                <td>${type}</td>
-                                <td>${description}</td>
-                                <td><span class="status-badge ${statusClass}">${statusText}</span></td>
-                            </tr>
-                        `;
-                    }).join('');
-                }
-                
-            } catch (error) {
-                console.error('Erro ao carregar atividades:', error);
-            }
-        }
-        
-        // ========================================
-        // FUNÇÕES DE AÇÃO
-        // ========================================
-        
-        async function handleApprove(userId) {
-            if (!confirm('Aprovar este profissional?')) return;
-            
-            try {
-                showAlert('Processando aprovação...', 'info');
-                
-                // Atualizar status para active
-                const { error } = await supabaseClient
-                    .from('users')
-                    .update({ 
-                        status: 'active',
-                        updated_at: new Date().toISOString()
-                    })
-                    .eq('id', userId);
-                
-                if (error) throw error;
-                
-                // Buscar dados do usuário para enviar email
-                const { data: user } = await supabaseClient
-                    .from('users')
-                    .select('*')
-                    .eq('id', userId)
-                    .single();
-                
-                // Enviar notificação (implementar depois com SendGrid/Resend)
-                await sendApprovalNotification(user);
-                
-                showAlert('✅ Profissional aprovado com sucesso!', 'success');
-                
-                // Recarregar dados
-                await loadDashboardData();
-                
-            } catch (error) {
-                console.error('Erro ao aprovar:', error);
-                showAlert('Erro ao aprovar profissional', 'error');
-            }
-        }
-        
-        async function handleReject(userId) {
-            const reason = prompt('Motivo da rejeição:');
-            if (!reason) return;
-            
-            try {
-                showAlert('Processando rejeição...', 'info');
-                
-                // Atualizar status para rejected
-                const { error } = await supabaseClient
-                    .from('users')
-                    .update({ 
-                        status: 'rejected',
-                        updated_at: new Date().toISOString()
-                    })
-                    .eq('id', userId);
-                
-                if (error) throw error;
-                
-                // Buscar dados do usuário
-                const { data: user } = await supabaseClient
-                    .from('users')
-                    .select('*')
-                    .eq('id', userId)
-                    .single();
-                
-                // Enviar notificação (implementar depois)
-                await sendRejectionNotification(user, reason);
-                
-                showAlert('❌ Profissional rejeitado', 'success');
-                
-                // Recarregar dados
-                await loadDashboardData();
-                
-            } catch (error) {
-                console.error('Erro ao rejeitar:', error);
-                showAlert('Erro ao rejeitar profissional', 'error');
-            }
-        }
-        
-        async function viewProfessional(userId) {
-            try {
-                const { data: prof, error } = await supabaseClient
-                    .from('users')
-                    .select(`
-                        *,
-                        subscriptions (
-                            plan,
-                            status,
-                            prescriptions_count,
-                            created_at
-                        )
-                    `)
-                    .eq('id', userId)
-                    .single();
-                
-                if (error) throw error;
-                
-                // Preencher modal
-                document.getElementById('modalName').textContent = prof.name || '-';
-                document.getElementById('modalEmail').textContent = prof.email || '-';
-                document.getElementById('modalCouncil').textContent = `${prof.council}-${prof.state}` || '-';
-                document.getElementById('modalRegister').textContent = prof.registration_number || '-';
-                document.getElementById('modalSpecialty').textContent = prof.specialty || 'Não informada';
-                document.getElementById('modalPhone').textContent = prof.phone || 'Não informado';
-                document.getElementById('modalDate').textContent = new Date(prof.created_at).toLocaleDateString('pt-BR');
-                document.getElementById('modalStatus').textContent = 
-                    prof.status === 'active' ? 'Ativo' :
-                    prof.status === 'rejected' ? 'Rejeitado' : 'Pendente';
-                
-                // Mostrar botões de ação se pendente
-                const approveBtn = document.getElementById('modalApproveBtn');
-                const rejectBtn = document.getElementById('modalRejectBtn');
-                
-                if (prof.status === 'pending') {
-                    approveBtn.style.display = 'inline-block';
-                    approveBtn.onclick = () => {
-                        closeModal();
-                        handleApprove(userId);
-                    };
-                    
-                    rejectBtn.style.display = 'inline-block';
-                    rejectBtn.onclick = () => {
-                        closeModal();
-                        handleReject(userId);
-                    };
-                } else {
-                    approveBtn.style.display = 'none';
-                    rejectBtn.style.display = 'none';
-                }
-                
-                // Mostrar modal
-                document.getElementById('professionalModal').classList.add('show');
-                
-            } catch (error) {
-                console.error('Erro ao buscar profissional:', error);
-                showAlert('Erro ao carregar detalhes', 'error');
-            }
-        }
-        
-        function closeModal() {
-            document.getElementById('professionalModal').classList.remove('show');
-        }
-        
-        // ========================================
-        // FUNÇÕES DE NOTIFICAÇÃO (PLACEHOLDER)
-        // ========================================
-        
-        async function sendApprovalNotification(user) {
-            // TODO: Implementar com SendGrid/Resend
-            console.log('Email de aprovação para:', user.email);
-            console.log(`
-                Assunto: ✅ Cadastro Aprovado - Receituário Pro
-                
-                Olá ${user.name},
-                
-                Seu cadastro foi aprovado! Você já pode acessar o sistema.
-                
-                Acesse: https://receituariopro.com.br/auth.html
-                
-                Atenciosamente,
-                Equipe Receituário Pro
-            `);
-        }
-        
-        async function sendRejectionNotification(user, reason) {
-            // TODO: Implementar com SendGrid/Resend
-            console.log('Email de rejeição para:', user.email);
-            console.log(`
-                Assunto: Cadastro não aprovado - Receituário Pro
-                
-                Olá ${user.name},
-                
-                Infelizmente não foi possível aprovar seu cadastro.
-                
-                Motivo: ${reason}
-                
-                Entre em contato conosco para mais informações.
-                
-                Atenciosamente,
-                Equipe Receituário Pro
-            `);
-        }
-        
-        // ========================================
-        // FUNÇÕES AUXILIARES
-        // ========================================
-        
-        function showAlert(message, type = 'info') {
-            const container = document.getElementById('alertContainer');
-            const alertId = 'alert-' + Date.now();
-            
-            const alertHtml = `
-                <div id="${alertId}" class="alert alert-${type}">
-                    <span>${type === 'success' ? '✅' : type === 'error' ? '❌' : 'ℹ️'}</span>
-                    <span>${message}</span>
-                </div>
-            `;
-            
-            container.innerHTML = alertHtml;
-            
-            // Auto-hide após 5 segundos
-            setTimeout(() => {
-                const alert = document.getElementById(alertId);
-                if (alert) alert.remove();
-            }, 5000);
-        }
-        
-        async function logout() {
-            if (!confirm('Deseja sair do painel administrativo?')) return;
-            
-            try {
-                const { error } = await supabaseClient.auth.signOut();
-                if (error) throw error;
-                
+        const MONTH_NAMES = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'];
+
+        document.addEventListener('DOMContentLoaded', init);
+
+        async function init() {
+            const { data: { session } } = await supabaseClient.auth.getSession();
+            if (!session) { window.location.href = 'auth.html'; return; }
+
+            const { data: user, error } = await supabaseClient
+                .from('users')
+                .select('name,is_admin')
+                .eq('id', session.user.id)
+                .single();
+
+            if (error || !user?.is_admin) {
                 window.location.href = 'index.html';
-            } catch (error) {
-                console.error('Erro ao fazer logout:', error);
-                showAlert('Erro ao sair', 'error');
+                return;
             }
+
+            document.getElementById('adminName').textContent = user.name || 'Admin';
+            document.getElementById('dashboard').classList.add('active');
+            document.getElementById('loadingScreen').classList.add('hidden');
+
+            await loadDashboardData();
         }
-        
-        // ========================================
-        // EVENT LISTENERS
-        // ========================================
-        
-        // Fechar modal ao clicar fora
-        window.addEventListener('click', (e) => {
-            if (e.target.classList.contains('modal')) {
-                e.target.classList.remove('show');
-            }
-        });
-        
-        // Atualização automática quando a aba volta ao foco
-        document.addEventListener('visibilitychange', () => {
-            if (!document.hidden) {
-                loadDashboardData();
-            }
-        });
+
+        async function loadDashboardData() {
+            const now = new Date();
+            const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+            const startOfYear = new Date(now.getFullYear(), 0, 1);
+
+            const [newUsersRes, trialRes, activeRes, usersYearRes] = await Promise.all([
+                supabaseClient.from('users').select('*', { count:'exact', head:true }).gte('created_at', startOfMonth.toISOString()),
+                supabaseClient.from('subscriptions').select('*', { count:'exact', head:true }).eq('plan','trial').eq('status','active'),
+                supabaseClient.from('subscriptions').select('*').eq('plan','essential').eq('status','active'),
+                supabaseClient.from('users').select('id,created_at').gte('created_at', startOfYear.toISOString())
+            ]);
+
+            const newUsers = newUsersRes.count || 0;
+            const trialCount = trialRes.count || 0;
+            const activeSubs = activeRes.data || [];
+            const usersYear = usersYearRes.data || [];
+
+            let monthlyCount = 0; let yearlyCount = 0;
+            activeSubs.forEach(s => {
+                const start = new Date(s.current_period_start);
+                const end = new Date(s.current_period_end);
+                const diffMonths = (end - start) / (1000*60*60*24*30);
+                if (diffMonths > 1.5) yearlyCount++; else monthlyCount++;
+            });
+            const activeCount = activeSubs.length;
+
+            const mrr = monthlyCount * 29 + yearlyCount * (348/12);
+            const monthsRemaining = 12 - now.getMonth();
+            const projected = mrr * monthsRemaining;
+
+            document.getElementById('newUsers').textContent = newUsers;
+            document.getElementById('trialUsers').textContent = trialCount;
+            document.getElementById('activeUsers').textContent = activeCount;
+            document.getElementById('monthlySubs').textContent = monthlyCount;
+            document.getElementById('yearlySubs').textContent = yearlyCount;
+            document.getElementById('monthlyRevenue').textContent = `R$ ${mrr.toFixed(2)}`;
+            document.getElementById('projectedRevenue').textContent = `R$ ${projected.toFixed(2)}`;
+
+            // Users per month chart
+            const usersPerMonth = new Array(12).fill(0);
+            usersYear.forEach(u => { usersPerMonth[new Date(u.created_at).getMonth()]++; });
+            const ctxUsers = document.getElementById('usersChart').getContext('2d');
+            new Chart(ctxUsers, {
+                type: 'bar',
+                data: { labels: MONTH_NAMES, datasets: [{ label: 'Usuários', data: usersPerMonth, backgroundColor: '#667eea' }] },
+                options: { scales: { y: { beginAtZero: true } } }
+            });
+
+            // Plan distribution chart
+            const ctxPlan = document.getElementById('planChart').getContext('2d');
+            new Chart(ctxPlan, {
+                type: 'doughnut',
+                data: { labels: ['Mensal','Anual'], datasets: [{ data: [monthlyCount, yearlyCount], backgroundColor: ['#764ba2','#667eea'] }] }
+            });
+
+            // Revenue projection chart
+            const projLabels = MONTH_NAMES.slice(now.getMonth());
+            const projData = new Array(projLabels.length).fill(mrr.toFixed(2));
+            const ctxRev = document.getElementById('revenueChart').getContext('2d');
+            new Chart(ctxRev, {
+                type: 'line',
+                data: { labels: projLabels, datasets: [{ label: 'Receita projetada', data: projData, borderColor: '#48bb78', backgroundColor: 'rgba(72,187,120,0.2)', tension: 0.2 }] },
+                options: { scales: { y: { beginAtZero: true } } }
+            });
+        }
+
+        async function logout() {
+            await supabaseClient.auth.signOut();
+            window.location.href = 'index.html';
+        }
     </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace user approval dashboard with analytics overview
- Display live stats for new users, trials, active plans, monthly vs annual distribution, and revenue projections
- Add charts for user growth, plan mix, and projected revenue using real Supabase data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68adf95dbe00833292933550334c4561