### PR TITLE
feat: add templated email system

### DIFF
--- a/supabase/functions/send-templated-email/index.ts
+++ b/supabase/functions/send-templated-email/index.ts
@@ -1,0 +1,116 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+const FROM_EMAIL = Deno.env.get("FROM_EMAIL") ?? "noreply@example.com";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const RESET_REDIRECT_URL = Deno.env.get("RESET_REDIRECT_URL") ??
+  "https://receituariopro.com.br/auth.html?reset=true";
+
+interface EmailRequest {
+  to: string;
+  template: string;
+  data?: Record<string, string>;
+}
+
+const TEMPLATE_MAP: Record<string, { file: string; subject: string }> = {
+  welcome: {
+    file: "welcome.html",
+    subject: "🎉 Bem-vindo ao Receituário Pro!",
+  },
+  trial_expiring: {
+    file: "trial_expiring.html",
+    subject: "⏰ Seu trial está acabando",
+  },
+  plan_expired: { file: "plan_expired.html", subject: "🚫 Seu plano expirou" },
+  password_reset: {
+    file: "password_reset.html",
+    subject: "🔐 Redefinição de senha",
+  },
+  approval: {
+    file: "approval.html",
+    subject: "✅ Cadastro Aprovado - Receituário Pro",
+  },
+  rejection: {
+    file: "rejection.html",
+    subject: "❌ Cadastro Reprovado - Receituário Pro",
+  },
+};
+
+function renderTemplate(content: string, data: Record<string, string>): string {
+  return content.replace(/{{(\w+)}}/g, (_, key) => data[key] ?? "");
+}
+
+async function generateResetLink(email: string): Promise<string> {
+  const response = await fetch(`${SUPABASE_URL}/auth/v1/admin/generate-link`, {
+    method: "POST",
+    headers: {
+      "apikey": SERVICE_ROLE_KEY,
+      "Authorization": `Bearer ${SERVICE_ROLE_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      type: "recovery",
+      email,
+      options: { redirect_to: RESET_REDIRECT_URL },
+    }),
+  });
+
+  const json = await response.json();
+  if (!response.ok) {
+    throw new Error(json.error?.message || "Failed to generate reset link");
+  }
+  return json.action_link as string;
+}
+
+serve(async (req) => {
+  try {
+    const { to, template, data = {} } = await req.json() as EmailRequest;
+
+    const info = TEMPLATE_MAP[template];
+    if (!info) {
+      throw new Error("Invalid template");
+    }
+
+    const templateUrl = new URL(`./templates/${info.file}`, import.meta.url);
+    let html = await Deno.readTextFile(templateUrl);
+
+    const finalData = { ...data };
+
+    if (template === "password_reset") {
+      finalData.reset_link = await generateResetLink(to);
+    }
+
+    html = renderTemplate(html, finalData);
+
+    const resendRes = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: FROM_EMAIL,
+        to: [to],
+        subject: info.subject,
+        html,
+      }),
+    });
+
+    const result = await resendRes.json();
+    if (!resendRes.ok) {
+      throw new Error(result.message || "Failed to send email");
+    }
+
+    return new Response(JSON.stringify({ success: true, id: result.id }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Templated email error:", error);
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { status: 400 },
+    );
+  }
+});

--- a/supabase/functions/send-templated-email/templates/approval.html
+++ b/supabase/functions/send-templated-email/templates/approval.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Cadastro aprovado</h1>
+    <p>Olá Dr(a). {{name}},</p>
+    <p>Seu cadastro foi aprovado. Acesse o sistema para começar a usar:</p>
+    <p><a href="{{login_url}}">Fazer login</a></p>
+  </body>
+</html>

--- a/supabase/functions/send-templated-email/templates/password_reset.html
+++ b/supabase/functions/send-templated-email/templates/password_reset.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Redefinição de senha</h1>
+    <p>Para redefinir sua senha, clique no link abaixo:</p>
+    <p><a href="{{reset_link}}">Resetar senha</a></p>
+    <p>Se você não solicitou, ignore este email.</p>
+    <p>Dúvidas? Contate {{support_email}}</p>
+  </body>
+</html>

--- a/supabase/functions/send-templated-email/templates/plan_expired.html
+++ b/supabase/functions/send-templated-email/templates/plan_expired.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Plano expirado</h1>
+    <p>Olá Dr(a). {{name}},</p>
+    <p>
+      Seu plano expirou. Para voltar a usar o Receituário Pro, renove seu
+      acesso:
+    </p>
+    <p><a href="{{upgrade_link}}">Escolher plano</a></p>
+  </body>
+</html>

--- a/supabase/functions/send-templated-email/templates/rejection.html
+++ b/supabase/functions/send-templated-email/templates/rejection.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Cadastro reprovado</h1>
+    <p>Olá Dr(a). {{name}},</p>
+    <p>Seu cadastro foi reprovado pelo seguinte motivo:</p>
+    <p>{{reason}}</p>
+    <p>Em caso de dúvidas, responda este email.</p>
+  </body>
+</html>

--- a/supabase/functions/send-templated-email/templates/trial_expiring.html
+++ b/supabase/functions/send-templated-email/templates/trial_expiring.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Seu trial termina em {{days_left}} dias</h1>
+    <p>Olá Dr(a). {{name}},</p>
+    <p>Para continuar usando o Receituário Pro, escolha um plano:</p>
+    <p>
+      <a href="{{upgrade_yearly_link}}">Plano anual</a> | <a
+        href="{{upgrade_monthly_link}}"
+      >Plano mensal</a>
+    </p>
+  </body>
+</html>

--- a/supabase/functions/send-templated-email/templates/welcome.html
+++ b/supabase/functions/send-templated-email/templates/welcome.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333">
+    <h1>Receituário Pro</h1>
+    <p>Olá Dr(a). {{name}},</p>
+    <p>Bem-vindo ao Receituário Pro! Seu trial de 30 dias já está ativo.</p>
+    <p><strong>Email:</strong> {{email}}</p>
+    <p><strong>Registro:</strong> {{council}}-{{state}} {{registration}}</p>
+    <p><strong>Especialidade:</strong> {{specialty}}</p>
+    <p><a href="{{app_url}}">Acessar o aplicativo</a></p>
+    <p>Dúvidas? Contate {{support_email}}</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add edge function to send Resend emails from reusable HTML templates
- centralize email helpers for welcome, approval, plan and trial status, and password reset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `deno fmt supabase/functions/send-templated-email/index.ts supabase/functions/send-templated-email/templates/*.html`
- `deno lint supabase/functions/send-templated-email/index.ts`


------
https://chatgpt.com/codex/tasks/task_b_68ae0cf53c948332b91b732a0c6c2f57