### PR TITLE
Improve template confirmations and export signatures

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -423,7 +423,15 @@ cursor: pointer;
 color: var(--text-light);
 }
 .modal-body {
-padding: 20px;
+    padding: 20px;
+}
+
+.modal-actions {
+    padding: 20px;
+    border-top: 1px solid var(--gray-lighter);
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
 }
 /* History List */
 .history-list {

--- a/js/modules/app.controller.js
+++ b/js/modules/app.controller.js
@@ -19,8 +19,7 @@ async initialize() {
         const subscriptionStatus = await window.SubscriptionModule.loadSubscription(user.id);        // 4. Configurar UI com dados do usuário
         this.setupUserInterface(professionalInfo, subscriptionStatus);        // 5. Inicializar módulos
         await this.initializeModules();        // 6. Configurar event listeners
-        this.setupEventListeners();        // 7. Carregar rascunho se existir
-        this.loadDraftIfExists();        // 8. Verificar status da assinatura
+        this.setupEventListeners();        // 7. Verificar status da assinatura
         if (!subscriptionStatus.hasAccess) {
             this.handleExpiredTrial();
         }        // Marcar como inicializado
@@ -134,20 +133,9 @@ initializeDate() {
         dateInput.valueAsDate = new Date();
         window.UIModule.updateDateDisplay();
     }
-}/**
- * Carregar rascunho se existir
- */
-loadDraftIfExists() {
-    const draft = window.PrescriptionsModule.loadDraft();
-    if (draft) {
-        // Perguntar se quer recuperar
-        if (confirm('Há um rascunho salvo. Deseja recuperá-lo?')) {
-            document.getElementById('patientName').value = draft.patientName || '';
-            document.getElementById('prescriptionTextArea').innerHTML = draft.content || '';            window.UIModule.updatePatientDisplay();
-            window.UIModule.showToast('Rascunho recuperado', 'success');
-        }
-    }
-}/**
+}
+
+/**
  * Lidar com trial expirado
  */
 handleExpiredTrial() {

--- a/js/modules/export.module.js
+++ b/js/modules/export.module.js
@@ -9,8 +9,20 @@ this.jsPDF = window.jspdf?.jsPDF;
  */
 prepareForExport() {
     const preview = document.getElementById('prescriptionPreview');
-    if (!preview) return null;    // Criar clone para não afetar o original
-    const clone = preview.cloneNode(true);    // Remover elementos não exportáveis
+    if (!preview) return null;
+
+    // Criar clone para não afetar o original
+    const clone = preview.cloneNode(true);
+
+    // Copiar conteúdo da assinatura
+    const originalCanvas = preview.querySelector('#signatureCanvas');
+    const cloneCanvas = clone.querySelector('#signatureCanvas');
+    if (originalCanvas && cloneCanvas) {
+        const ctx = cloneCanvas.getContext('2d');
+        ctx.drawImage(originalCanvas, 0, 0);
+    }
+
+    // Remover elementos não exportáveis
     const editableElements = clone.querySelectorAll('[contenteditable]');
     editableElements.forEach(el => {
         el.removeAttribute('contenteditable');

--- a/js/modules/templates.module.js
+++ b/js/modules/templates.module.js
@@ -109,7 +109,7 @@ renderTemplateGrid() {
 }/**
  * Selecionar template
  */
-selectTemplate(templateId) {
+async selectTemplate(templateId) {
     // Validar template
     if (!this.templates[templateId]) return;    const textArea = document.getElementById('prescriptionTextArea');
     if (!textArea) return;    // Verificar se o conteúdo atual é de um template ou foi editado
@@ -119,19 +119,16 @@ selectTemplate(templateId) {
     if (isEmpty || isTemplateContent || templateId === 'livre') {
         // Perguntar confirmação se houver conteúdo personalizado
         if (!isEmpty && !isTemplateContent && templateId !== 'livre') {
-            if (!confirm('Você tem conteúdo personalizado. Deseja substituir pelo template?')) {
-                // Manter o template atual selecionado visualmente
+            if (!(await window.UIModule.confirm('Deseja descartar as alterações na receita?'))) {
                 this.updateTemplateUI(this.currentTemplate);
                 return;
             }
-        }        // Carregar novo template
+        }
         this.loadTemplateContent(templateId);
     } else if (!isTemplateContent && templateId !== this.currentTemplate) {
-        // Tem conteúdo editado e está mudando de template
-        if (confirm('Deseja substituir o conteúdo atual pelo template?')) {
+        if (await window.UIModule.confirm('Deseja descartar as alterações na receita?')) {
             this.loadTemplateContent(templateId);
         } else {
-            // Manter o template atual selecionado visualmente
             this.updateTemplateUI(this.currentTemplate);
             return;
         }

--- a/js/modules/ui.module.js
+++ b/js/modules/ui.module.js
@@ -82,8 +82,41 @@ hideModal(modalId) {
  */
 async confirm(message, title = 'Confirmação') {
     return new Promise((resolve) => {
-        const result = window.confirm(message);
-        resolve(result);
+        const container = document.getElementById('modalsContainer');
+
+        if (!container) {
+            resolve(window.confirm(message));
+            return;
+        }
+
+        container.innerHTML = `
+            <div class="modal" id="confirmModal">
+                <div class="modal-content">
+                    <div class="modal-body">
+                        <p>${message}</p>
+                    </div>
+                    <div class="modal-actions">
+                        <button id="confirmCancel" class="btn btn-secondary">Cancelar</button>
+                        <button id="confirmOk" class="btn btn-primary">Confirmar</button>
+                    </div>
+                </div>
+            </div>`;
+
+        const modal = document.getElementById('confirmModal');
+        modal.classList.add('show');
+
+        const cleanup = (result) => {
+            modal.classList.remove('show');
+            container.innerHTML = '';
+            resolve(result);
+        };
+
+        document.getElementById('confirmCancel').onclick = () => cleanup(false);
+        document.getElementById('confirmOk').onclick = () => cleanup(true);
+
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) cleanup(false);
+        });
     });
 }
 

--- a/js/supabase-config.js
+++ b/js/supabase-config.js
@@ -152,7 +152,7 @@ async function sendPlanExpiredEmail(user) {
 async function sendPasswordResetEmail(email) {
     try {
         const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
-            redirectTo: 'https://www.receituariopro.com.br/update-password.html'
+            redirectTo: 'https://receituariopro.com.br/update-password.html'
         });
 
         if (error) throw error;


### PR DESCRIPTION
## Summary
- Fix password reset redirect to apex domain
- Remove intrusive draft recovery prompt
- Add friendly discard confirmation modal
- Preserve signatures in PDF/PNG exports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ae237db2488332a0bb0f35bcd0777f