### PR TITLE
feat: replace underscores with styled blanks

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -293,7 +293,27 @@ line-height: 1.8;
 outline: none;
 }
 .prescription-text-area:focus {
-border-color: var(--primary);
+    border-color: var(--primary);
+}
+
+/* Dynamic blank lines and placeholders */
+.blank-line {
+    display: inline-block;
+    min-width: 200px;
+    border-bottom: 1px solid #000;
+}
+
+.blank-line.short {
+    min-width: 60px;
+}
+
+.blank-line:empty::before {
+    content: '\00a0';
+}
+
+.placeholder:empty::before {
+    content: attr(data-placeholder);
+    color: var(--text-light);
 }
 /* Signature Section */
 .signature-section {

--- a/js/modules/export.module.js
+++ b/js/modules/export.module.js
@@ -26,7 +26,17 @@ prepareForExport() {
     const editableElements = clone.querySelectorAll('[contenteditable]');
     editableElements.forEach(el => {
         el.removeAttribute('contenteditable');
-    });    // Aplicar estilos de impressão
+    });
+
+    // Remover linhas e placeholders vazios
+    clone.querySelectorAll('.blank-line').forEach(el => {
+        if (!el.textContent.trim()) el.remove();
+    });
+    clone.querySelectorAll('.placeholder').forEach(el => {
+        if (!el.textContent.trim()) el.remove();
+    });
+
+    // Aplicar estilos de impressão
     clone.style.width = '210mm';
     clone.style.minHeight = '297mm';
     clone.style.padding = '20mm';    return clone;

--- a/js/modules/templates.module.js
+++ b/js/modules/templates.module.js
@@ -15,15 +15,14 @@ loadTemplates() {
             title: 'Receituário de Medicação',
             icon: '💊',
             content: `<strong>USO INTERNO</strong><br><br>
-
-________________________________<br>
-Posologia: _____________________<br>
-Quantidade: ____________________<br><br>
-________________________________<br>
-Posologia: _____________________<br>
-Quantidade: ____________________<br><br>
+<span class="blank-line" contenteditable="true"></span><br>
+Posologia: <span class="blank-line" contenteditable="true"></span><br>
+Quantidade: <span class="blank-line" contenteditable="true"></span><br><br>
+<span class="blank-line" contenteditable="true"></span><br>
+Posologia: <span class="blank-line" contenteditable="true"></span><br>
+Quantidade: <span class="blank-line" contenteditable="true"></span><br><br>
 <strong>Orientações:</strong><br>
-_________________________________`
+<span class="blank-line" contenteditable="true"></span>`
 },
         exames: {
             title: 'Solicitação de Exames',
@@ -35,21 +34,21 @@ _________________________________`
 ☐ Triglicerídeos<br>
 ☐ TSH e T4 livre<br>
 ☐ Urina tipo I<br>
-☐ _______________________________<br><br>
+☐ <span class="blank-line" contenteditable="true"></span><br><br>
 <strong>Hipótese diagnóstica / CID-10:</strong><br>
 <span class="cid-field" contenteditable="false" onclick="window.CIDModule.openSearch(this)">
 <span class="cid-placeholder">Clique para buscar CID...</span>
 </span><br><br>
-_________________________________`
+<span class="blank-line" contenteditable="true"></span>`
 },        procedimento: {
             title: 'Encaminhamento',
             icon: '🏥',
             content: `<strong>ENCAMINHAMENTO MÉDICO</strong><br><br>
 Prezado(a) Colega,<br><br>
 Encaminho o(a) paciente para:<br>
-_________________________________<br><br>
+<span class="blank-line" contenteditable="true"></span><br><br>
 Motivo do encaminhamento:<br>
-_________________________________<br><br>
+<span class="blank-line" contenteditable="true"></span><br><br>
 <strong>Diagnóstico / CID-10:</strong><br>
 <span class="cid-field" contenteditable="false" onclick="window.CIDModule.openSearch(this)">
 <span class="cid-placeholder">Clique para buscar CID...</span>
@@ -60,8 +59,8 @@ Atenciosamente,`
             icon: '📋',
             content: `<strong>ATESTADO MÉDICO</strong><br><br>
 Atesto que o(a) paciente acima necessita se afastar de suas atividades por:<br>
-_________________________________<br><br>
-Período: _____ dias<br><br>
+<span class="blank-line" contenteditable="true"></span><br><br>
+Período: <span class="blank-line short" contenteditable="true"></span> dias<br><br>
 <strong>CID-10:</strong><br>
 <span class="cid-field" contenteditable="false" onclick="window.CIDModule.openSearch(this)">
 <span class="cid-placeholder">Clique para buscar CID...</span>
@@ -72,14 +71,14 @@ Por ser verdade, firmo o presente.`
             icon: '📄',
             content: `<strong>LAUDO MÉDICO</strong><br><br>
 <strong>Exame realizado:</strong><br>
-_________________________________<br><br>
+<span class="blank-line" contenteditable="true"></span><br><br>
 <strong>Achados:</strong><br>
-_________________________________<br><br>
+<span class="blank-line" contenteditable="true"></span><br><br>
 <strong>Conclusão / CID-10:</strong><br>
 <span class="cid-field" contenteditable="false" onclick="window.CIDModule.openSearch(this)">
 <span class="cid-placeholder">Clique para buscar CID...</span>
 </span><br><br>
-_________________________________`
+<span class="blank-line" contenteditable="true"></span>`
 },        livre: {
             title: 'Receituário Livre',
             icon: '✏️',

--- a/js/modules/ui.module.js
+++ b/js/modules/ui.module.js
@@ -199,8 +199,9 @@ updatePatientDisplay() {
     
     if (display) {
         const date = this.getFormattedDate();
+        const nameDisplay = patientName || '<span class="placeholder" data-placeholder="Nome do paciente"></span>';
         display.innerHTML = `
-            <p><strong>Paciente:</strong> ${patientName || '_________________________'}</p>
+            <p><strong>Paciente:</strong> ${nameDisplay}</p>
             <p><strong>Data:</strong> ${date}</p>
         `;
     }
@@ -214,8 +215,9 @@ updateDateDisplay() {
     if (display) {
         const patientName = document.getElementById('patientName').value;
         const date = this.getFormattedDate();
+        const nameDisplay = patientName || '<span class="placeholder" data-placeholder="Nome do paciente"></span>';
         display.innerHTML = `
-            <p><strong>Paciente:</strong> ${patientName || '_________________________'}</p>
+            <p><strong>Paciente:</strong> ${nameDisplay}</p>
             <p><strong>Data:</strong> ${date}</p>
         `;
     }


### PR DESCRIPTION
## Summary
- style blank lines and patient placeholders with CSS instead of underscores
- clean up unused blank lines and placeholders when exporting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ae3fcef148833290799d8b239f07d9