### PR TITLE
Remove .html extensions and localize errors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,7 +16,7 @@ ReceituarioPro é um SaaS de geração de receituários médicos. A aplicação 
    - Injetar essas variáveis no `js/supabase-config.js` durante o build ou via script backend.
    - Remover qualquer chave embutida no frontend e rotacionar credenciais existentes.
 2. **Remover código legado**
-   - Arquivos como `css/styles.css` e `js/app.js` não são utilizados pelo `app.html`.
+   - Arquivos como `css/styles.css` e `js/app.js` não são utilizados pelo `app`.
    - Consolidar funcionalidades duplicadas dos módulos antigos (`js/*.js`) nos módulos atuais (`js/modules`).
 3. **Unificar utilitários de UI e templates**
    - Centralizar toasts e indicadores de carregamento no `js/modules/ui.module.js`.
@@ -47,7 +47,7 @@ ReceituarioPro é um SaaS de geração de receituários médicos. A aplicação 
 - Animações e interações
 - Links para autenticação e pagamento
 
-### 2. Sistema de Autenticação (`auth.html`)
+### 2. Sistema de Autenticação (`auth`)
 - Login, cadastro e recuperação de senha
 - Validação de campos
 - Integração parcial com Supabase

--- a/admin/index.html
+++ b/admin/index.html
@@ -126,7 +126,7 @@
     <div class="dashboard" id="dashboard">
         <header class="admin-header">
             <div class="admin-logo">
-                <img src="img/saas-logo.png" alt="Logo">
+                <img src="/img/saas-logo.png" alt="Logo">
                 <span>Receituário Pro</span>
             </div>
             <div class="admin-user">
@@ -260,7 +260,7 @@
 
     <div id="toastContainer"></div>
 
-    <script src="js/supabase-config.js"></script>
+    <script src="/js/supabase-config.js"></script>
     <script>
         const MONTH_NAMES = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'];
         let usersData = [];
@@ -279,7 +279,7 @@
 
         async function init() {
             const { data: { session } } = await supabaseClient.auth.getSession();
-            if (!session) { window.location.href = 'auth.html'; return; }
+            if (!session) { window.location.href = '/auth'; return; }
 
             const { data: user, error } = await supabaseClient
                 .from('users')
@@ -288,7 +288,7 @@
                 .single();
 
             if (error || !user?.is_admin) {
-                window.location.href = 'index.html';
+                window.location.href = '/';
                 return;
             }
 
@@ -580,7 +580,7 @@
 
         async function logout() {
             await supabaseClient.auth.signOut();
-            window.location.href = 'index.html';
+            window.location.href = '/';
         }
     </script>
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script><!-- Libraries -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script><!-- CSS -->
-<link rel="stylesheet" href="css/app.css">
+<link rel="stylesheet" href="/css/app.css">
 </head>
 <body>
     <!-- Loading Screen -->
@@ -18,13 +18,13 @@
     <!-- Header -->
     <header class="header">
         <h1>
-            <img src="img/saas-logo.png" alt="Logo">
+            <img src="/img/saas-logo.png" alt="Logo">
             Receituário Pro
         </h1>
         <div class="header-actions">
             <div class="trial-info" id="trialInfo"></div>
             <div class="user-info" id="userInfo"></div>
-            <a href="profile.html" class="btn btn-white">👤 Perfil</a>
+            <a href="/profile" class="btn btn-white">👤 Perfil</a>
             <button class="btn btn-white" id="logoutBtn">Sair</button>
         </div>
     </header>    <div class="main-layout">
@@ -83,16 +83,16 @@
 </div><!-- Modals -->
 <div id="modalsContainer"></div><!-- Toast -->
 <div class="toast" id="toast"></div><!-- Scripts (ordem importa!) -->
-<script src="js/supabase-config.js"></script>
-<script src="js/modules/constants.js"></script>
-<script src="js/modules/auth.module.js"></script>
-<script src="js/modules/subscription.module.js"></script>
-<script src="js/modules/ui.module.js"></script>
-<script src="js/modules/templates.module.js"></script>
-<script src="js/modules/signature.module.js"></script>
-<script src="js/modules/prescriptions.module.js"></script>
-<script src="js/modules/export.module.js"></script>
-<script src="js/modules/app.controller.js"></script>
-<script src="js/modules/cid.module.js"></script>
+<script src="/js/supabase-config.js"></script>
+<script src="/js/modules/constants.js"></script>
+<script src="/js/modules/auth.module.js"></script>
+<script src="/js/modules/subscription.module.js"></script>
+<script src="/js/modules/ui.module.js"></script>
+<script src="/js/modules/templates.module.js"></script>
+<script src="/js/modules/signature.module.js"></script>
+<script src="/js/modules/prescriptions.module.js"></script>
+<script src="/js/modules/export.module.js"></script>
+<script src="/js/modules/app.controller.js"></script>
+<script src="/js/modules/cid.module.js"></script>
 </body>
 </html>

--- a/auth/index.html
+++ b/auth/index.html
@@ -8,7 +8,7 @@
     
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="js/supabase-config.js"></script>
+    <script src="/js/supabase-config.js"></script>
 <script>
     // Debug para verificar se o Supabase carregou
     console.log('Supabase disponível?', typeof window.supabase !== 'undefined');
@@ -528,7 +528,7 @@
         <div class="auth-sidebar">
             <div class="sidebar-content">
                 <div class="logo-section">
-                    <img src="img/saas-logo.png" alt="Receituário Pro">
+                    <img src="/img/saas-logo.png" alt="Receituário Pro">
                     <h1>Receituário Pro</h1>
                 </div>
                 <h2>Sistema Exclusivo para Profissionais da Saúde</h2>
@@ -952,7 +952,7 @@
                             showAlert('Seu trial de 30 dias expirou. Faça upgrade para continuar usando o sistema.', 'warning');
                             // Redirecionar para página de pagamento após 3 segundos
                             setTimeout(() => {
-                                window.location.href = 'index.html#pricing';
+                                window.location.href = '/#pricing';
                             }, 3000);
                         } else {
                             showAlert('Problema com sua assinatura. Entre em contato com o suporte.', 'error');
@@ -965,7 +965,7 @@
                     // ✅ LOGIN SUCESSO - REDIRECIONAR PARA APP
                     showAlert('Login realizado com sucesso! Redirecionando...', 'success');
                     setTimeout(() => {
-                        window.location.href = 'app.html';
+                        window.location.href = '/app';
                     }, 1000);
                 } else {
                     const detail = result.details ? ` Detalhes: ${result.details}` : '';
@@ -975,8 +975,7 @@
                 }
             } catch (error) {
                 console.error('Login error:', error);
-                const message = error.message || error;
-                showAlert(`Erro ao fazer login: ${message}`, 'error');
+                showAlert('Erro inesperado ao fazer login. Tente novamente.', 'error');
                 button.disabled = false;
                 btnText.textContent = 'Entrar';
             }
@@ -1064,8 +1063,7 @@
                 }
             } catch (error) {
                 console.error('Registration error:', error);
-                const message = error.message || error;
-                showAlert(`Erro ao criar conta: ${message}`, 'error');
+                showAlert('Erro inesperado ao criar conta. Tente novamente.', 'error');
                 button.disabled = false;
                 btnText.textContent = '🎁 Começar Trial Grátis';
             }

--- a/confirm/index.html
+++ b/confirm/index.html
@@ -6,7 +6,7 @@
     <title>Confirmação de Email - Receituário Pro</title>
     
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="js/supabase-config.js"></script>
+    <script src="/js/supabase-config.js"></script>
     
     <style>
         :root {
@@ -161,7 +161,7 @@
                 Sua conta foi confirmada com sucesso. 
                 Você será redirecionado para o login em <span id="countdown">5</span> segundos...
             </p>
-            <a href="auth.html" class="btn">Ir para Login</a>
+            <a href="/auth" class="btn">Ir para Login</a>
         </div>
         
         <!-- Estado: Erro -->
@@ -175,7 +175,7 @@
                 O link pode ter expirado ou já foi utilizado.
             </p>
             <div class="error-details" id="errorDetails" style="display: none;"></div>
-            <a href="auth.html" class="btn">Voltar ao Login</a>
+            <a href="/auth" class="btn">Voltar ao Login</a>
         </div>
         
         <!-- Estado: Reset de Senha -->
@@ -274,7 +274,7 @@
                         countdownEl.textContent = seconds;
                         if (seconds <= 0) {
                             clearInterval(interval);
-                            window.location.href = 'auth.html';
+                            window.location.href = '/auth';
                         }
                     }, 1000);
                     
@@ -285,7 +285,7 @@
                 }
             } catch (error) {
                 console.error('Confirmation error:', error);
-                showError('Erro ao confirmar email: ' + error.message);
+                showError('Erro ao confirmar email. Tente novamente.');
             }
         }
         
@@ -306,7 +306,7 @@
                 
             } catch (error) {
                 console.error('Reset error:', error);
-                showError('Erro ao processar reset: ' + error.message);
+                showError('Erro ao processar redefinição de senha. Tente novamente.');
             }
         }
         
@@ -343,11 +343,11 @@
                 // Sign out and redirect
                 setTimeout(async () => {
                     await supabaseClient.auth.signOut();
-                    window.location.href = 'auth.html';
+                    window.location.href = '/auth';
                 }, 3000);
                 
             } catch (error) {
-                alert('Erro ao redefinir senha: ' + error.message);
+                alert('Erro ao redefinir senha. Tente novamente.');
             }
         });
         
@@ -362,11 +362,11 @@
                 if (error) throw error;
                 
                 // Redirect to app
-                window.location.href = 'app.html';
+                window.location.href = '/app';
                 
             } catch (error) {
                 console.error('Magic link error:', error);
-                showError('Erro ao processar login: ' + error.message);
+                showError('Erro ao processar login. Tente novamente.');
             }
         }
         

--- a/index.html
+++ b/index.html
@@ -1098,7 +1098,7 @@
                 <a href="#why-choose">Por Que Escolher</a>
                 <a href="#pricing">Preços</a>
                 <a href="#faq">FAQ</a>
-                <a href="auth.html" class="cta-button">Acessar Sistema</a>
+                <a href="/auth" class="cta-button">Acessar Sistema</a>
             </div>
             <div class="mobile-menu" id="mobileMenu">
                 <span></span>
@@ -1135,7 +1135,7 @@
                 </div>
                 
                 <div class="hero-cta">
-                    <a href="auth.html" class="btn-primary">Começar Teste Grátis</a>
+                    <a href="/auth" class="btn-primary">Começar Teste Grátis</a>
                    <!-- <a href="#demo" class="btn-secondary">Ver Demonstração</a> -->
                 </div>
                 
@@ -1394,7 +1394,7 @@
                             <li>✅ Suporte prioritário</li>
                             <li>✅ Conformidade LGPD</li>
                         </ul>
-                        <a href="auth.html" class="btn-primary" style="width: 100%; text-align: center;">🚀 Começar Trial Grátis</a>
+                        <a href="/auth" class="btn-primary" style="width: 100%; text-align: center;">🚀 Começar Trial Grátis</a>
                         <small style="display: block; text-align: center; margin-top: 10px; color: var(--text-light);">
                             30 dias grátis • Sem cartão de crédito • Cancele quando quiser
                         </small>
@@ -1501,7 +1501,7 @@
                 <a href="#features">Recursos</a>
                 <a href="#pricing">Preços</a>
                 <a href="#why-choose">Benefícios</a>
-                <a href="app.html">Acessar Sistema</a>
+                <a href="/app">Acessar Sistema</a>
             </div>
             
             <div class="footer-column">

--- a/js/modules/auth.module.js
+++ b/js/modules/auth.module.js
@@ -23,7 +23,7 @@ async initialize() {
         
         // Verificar se é admin
         if (this.isAdmin()) {
-            window.location.href = 'admin.html';
+            window.location.href = '/admin';
             return false;
         }
 
@@ -81,7 +81,7 @@ async logout() {
  * Redirecionar para login
  */
 redirectToLogin() {
-    window.location.href = 'auth.html';
+    window.location.href = '/auth';
 }
 
 /**

--- a/js/modules/cid.module.js
+++ b/js/modules/cid.module.js
@@ -376,8 +376,7 @@ async searchCID(query) {
     const resultsContainer = document.getElementById('cidSearchResults');
     resultsContainer.innerHTML = `
         <div class="cid-no-results">
-            Erro ao buscar. Tente novamente.
-            <br><small>${error.message}</small>
+            Erro ao buscar. Tente novamente mais tarde.
         </div>
     `;
 }

--- a/profile/index.html
+++ b/profile/index.html
@@ -390,17 +390,17 @@
 </head>
 <body>
     <!-- Include Supabase Config -->
-    <script src="js/supabase-config.js"></script>
+    <script src="/js/supabase-config.js"></script>
     
     <div class="container">
         <!-- Header -->
         <div class="header">
             <h1>
-                <img src="img/saas-logo.png" alt="Logo" style="height: 32px;">
+                <img src="/img/saas-logo.png" alt="Logo" style="height: 32px;">
                 Meu Perfil
             </h1>
             <div class="nav-buttons">
-                <a href="app.html" class="btn btn-white">← Voltar ao Sistema</a>
+                <a href="/app" class="btn btn-white">← Voltar ao Sistema</a>
                 <button class="btn btn-white" onclick="logout()">Sair</button>
             </div>
         </div>
@@ -594,7 +594,7 @@
             // Check authentication
             const session = await checkSession();
             if (!session) {
-                window.location.href = 'auth.html';
+                window.location.href = '/auth';
                 return;
             }
 
@@ -676,7 +676,7 @@ async function loadSubscriptionData(userId) {
         if (error) {
             console.error('Erro ao buscar subscription:', error);
             planStatus.textContent = 'Erro ao carregar plano';
-            trialInfo.innerHTML = `<p style="color: var(--error);">Erro: ${error.message}</p>`;
+            trialInfo.innerHTML = '<p style="color: var(--error);">Erro ao carregar informações do plano</p>';
             upgradeBtn.textContent = 'Contatar Suporte';
             upgradeBtn.className = 'btn-primary error';
             return;
@@ -788,7 +788,7 @@ async function loadSubscriptionData(userId) {
     } catch (error) {
         console.error('Error loading subscription data:', error);
         document.getElementById('planStatus').textContent = 'Erro ao carregar plano';
-        document.getElementById('trialInfo').innerHTML = `<p style="color: var(--error);">Erro: ${error.message}</p>`;
+        document.getElementById('trialInfo').innerHTML = '<p style="color: var(--error);">Erro ao carregar informações do plano</p>';
     }
 }
 
@@ -1406,10 +1406,10 @@ async function debugSubscriptionConnection(userId) {
         async function logout() {
             try {
                 await supabaseClient.auth.signOut();
-                window.location.href = 'auth.html';
+                window.location.href = '/auth';
             } catch (error) {
                 console.error('Logout error:', error);
-                window.location.href = 'auth.html';
+                window.location.href = '/auth';
             }
         }
 

--- a/supabase/functions/send-templated-email/index.ts
+++ b/supabase/functions/send-templated-email/index.ts
@@ -5,7 +5,7 @@ const FROM_EMAIL = Deno.env.get("FROM_EMAIL") ?? "noreply@example.com";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const RESET_REDIRECT_URL = Deno.env.get("RESET_REDIRECT_URL") ??
-  "https://receituariopro.com.br/auth.html?reset=true";
+  "https://receituariopro.com.br/auth?reset=true";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/update-password/index.html
+++ b/update-password/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Alterar Senha - Receituário Pro</title>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="js/supabase-config.js"></script>
+    <script src="/js/supabase-config.js"></script>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- Serve pages without `.html` suffix by moving each page to a directory with `index.html` and updating links.
- Add Portuguese, user-friendly error messages across login, profile and confirmation flows.
- Update Supabase configuration and edge functions for new URLs.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68af342861e48332905c6c7f28152313